### PR TITLE
Expand test coverage for utilities, API routes, and components

### DIFF
--- a/src/__tests__/api/lessons/[id]/log-action/route.test.ts
+++ b/src/__tests__/api/lessons/[id]/log-action/route.test.ts
@@ -1,0 +1,101 @@
+import { POST } from "@/app/api/lessons/[id]/log-action/route";
+import { NextRequest } from "next/server";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+vi.mock("@/lib/lessonDeliveryAuth", () => ({
+  getCurrentTeacherFromDb: vi.fn(),
+}));
+
+vi.mock("@/lib/supabaseAdmin", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const mockTeacher = {
+  employeeNumber: 42,
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  authUserId: "auth-123",
+};
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/lessons/les-1/log-action", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "1.2.3.4",
+      "user-agent": "TestBrowser/1.0",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/lessons/[id]/log-action", () => {
+  const params = Promise.resolve({ id: "les-1" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(null);
+    const response = await POST(
+      createRequest({ action: "print_attempt" }),
+      { params }
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for invalid action", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+    const response = await POST(
+      createRequest({ action: "invalid" }),
+      { params }
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("logs action and returns ok for valid request", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+    const mockSb = {
+      from: vi.fn().mockReturnValue({ insert: insertMock }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await POST(
+      createRequest({ action: "print_attempt" }),
+      { params }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+
+    expect(mockSb.from).toHaveBeenCalledWith("lesson_access_log");
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 42,
+        lesson_id: "les-1",
+        action: "print_attempt",
+        ip_address: "1.2.3.4",
+        user_agent: "TestBrowser/1.0",
+      })
+    );
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+    const request = new NextRequest("http://localhost/api/lessons/les-1/log-action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const response = await POST(request, { params });
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/__tests__/api/lessons/route.test.ts
+++ b/src/__tests__/api/lessons/route.test.ts
@@ -1,0 +1,146 @@
+import { GET } from "@/app/api/lessons/route";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+vi.mock("@/lib/lessonDeliveryAuth", () => ({
+  getCurrentTeacherFromDb: vi.fn(),
+}));
+
+vi.mock("@/lib/supabaseAdmin", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const mockTeacher = {
+  employeeNumber: 42,
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  authUserId: "auth-123",
+};
+
+describe("GET /api/lessons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(null);
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns empty array when teacher has no assignments", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const mockSb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              or: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.lessons).toEqual([]);
+  });
+
+  it("returns lessons with curriculum data", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const mockSb = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "teacher_lesson_assignments") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  or: vi.fn().mockResolvedValue({
+                    data: [{ lesson_id: "les-1" }],
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "lessons") {
+          return {
+            select: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({
+                  data: [{
+                    id: "les-1",
+                    title: "Intro to Math",
+                    description: "Basic math",
+                    estimated_duration_minutes: 45,
+                    curriculum_id: "cur-1",
+                  }],
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "curricula") {
+          return {
+            select: vi.fn().mockReturnValue({
+              in: vi.fn().mockResolvedValue({
+                data: [{ id: "cur-1", title: "Mathematics", subject: "Math", grade_level: "3rd" }],
+                error: null,
+              }),
+            }),
+          };
+        }
+        return { select: vi.fn().mockReturnThis() };
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.lessons).toHaveLength(1);
+    expect(body.lessons[0]).toEqual({
+      lessonId: "les-1",
+      title: "Intro to Math",
+      description: "Basic math",
+      curriculumTitle: "Mathematics",
+      subject: "Math",
+      gradeLevel: "3rd",
+      estimatedDuration: 45,
+    });
+  });
+
+  it("returns 500 when assignment query fails", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const mockSb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              or: vi.fn().mockResolvedValue({
+                data: null,
+                error: { message: "DB error" },
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/__tests__/api/teacher/onboarding-status/route.test.ts
+++ b/src/__tests__/api/teacher/onboarding-status/route.test.ts
@@ -1,0 +1,171 @@
+import { GET } from "@/app/api/teacher/onboarding-status/route";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+vi.mock("@/lib/lessonDeliveryAuth", () => ({
+  getCurrentTeacherFromDb: vi.fn(),
+}));
+
+vi.mock("@/lib/supabaseAdmin", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const mockTeacher = {
+  employeeNumber: 42,
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  authUserId: "auth-123",
+};
+
+describe("GET /api/teacher/onboarding-status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(null);
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when user record not found", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const mockSb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: "Not found" } }),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            neq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(404);
+  });
+
+  it("returns fully onboarded status with all steps complete", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    let fromCallCount = 0;
+    const mockSb = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "users") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { requires_password_change: false, onboarding_status: "fully_onboarded" },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "w9_submissions") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { status: "completed" },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "signing_requests") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                neq: vi.fn().mockResolvedValue({
+                  data: [{ document_type: "contract", status: "completed" }],
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.onboardingStatus).toBe("fully_onboarded");
+    expect(body.steps).toEqual({
+      accountCreated: true,
+      passwordSet: true,
+      w9Submitted: true,
+      contractSigned: true,
+      bankConnected: true,
+      fullyOnboarded: true,
+    });
+  });
+
+  it("returns partial onboarding status", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+
+    const mockSb = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "users") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { requires_password_change: true, onboarding_status: "applied" },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "w9_submissions") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "signing_requests") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                neq: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          };
+        }
+        return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }),
+    };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSb as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.onboardingStatus).toBe("applied");
+    expect(body.steps.passwordSet).toBe(false);
+    expect(body.steps.w9Submitted).toBe(false);
+    expect(body.steps.contractSigned).toBe(false);
+    expect(body.steps.bankConnected).toBe(false);
+    expect(body.steps.fullyOnboarded).toBe(false);
+    expect(body.steps.accountCreated).toBe(true);
+  });
+});

--- a/src/__tests__/api/users/me/route.test.ts
+++ b/src/__tests__/api/users/me/route.test.ts
@@ -1,0 +1,53 @@
+import { GET } from "@/app/api/users/me/route";
+
+vi.mock("@/lib/lessonDeliveryAuth", () => ({
+  getCurrentTeacherFromDb: vi.fn(),
+}));
+
+import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
+
+describe("GET /api/users/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(null);
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns user info when authenticated", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue({
+      employeeNumber: 42,
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane@example.com",
+      authUserId: "auth-123",
+    });
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      email: "jane@example.com",
+      firstName: "Jane",
+      lastName: "Doe",
+      displayName: "Jane Doe",
+    });
+  });
+
+  it("uses 'Teacher' as fallback display name", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue({
+      employeeNumber: 1,
+      firstName: "",
+      lastName: "",
+      email: "anon@example.com",
+      authUserId: "auth-456",
+    });
+
+    const response = await GET();
+    const body = await response.json();
+    expect(body.displayName).toBe("Teacher");
+  });
+});

--- a/src/__tests__/components/OnboardingChecklist.test.tsx
+++ b/src/__tests__/components/OnboardingChecklist.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import OnboardingChecklist from "@/components/OnboardingChecklist";
+
+// Mock next/link to render a plain anchor
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+function mockFetch(data: Record<string, unknown>) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const allComplete = {
+  onboardingStatus: "fully_onboarded",
+  steps: {
+    accountCreated: true,
+    passwordSet: true,
+    w9Submitted: true,
+    contractSigned: true,
+    bankConnected: true,
+    fullyOnboarded: true,
+  },
+};
+
+const partialSteps = {
+  onboardingStatus: "applied",
+  steps: {
+    accountCreated: true,
+    passwordSet: false,
+    w9Submitted: false,
+    contractSigned: false,
+    bankConnected: false,
+    fullyOnboarded: false,
+  },
+};
+
+describe("OnboardingChecklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while loading", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    const { container } = render(<OnboardingChecklist />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when fully onboarded", async () => {
+    mockFetch(allComplete);
+    const { container } = render(<OnboardingChecklist />);
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("renders checklist when not fully onboarded", async () => {
+    mockFetch(partialSteps);
+    render(<OnboardingChecklist />);
+    await waitFor(() => {
+      expect(screen.getByText("Getting Started")).toBeTruthy();
+    });
+    expect(screen.getByText(/1 of 6 complete/)).toBeTruthy();
+  });
+
+  it("shows step titles", async () => {
+    mockFetch(partialSteps);
+    render(<OnboardingChecklist />);
+    await waitFor(() => {
+      expect(screen.getByText(/1\. Account Created/)).toBeTruthy();
+      expect(screen.getByText(/2\. Set Password/)).toBeTruthy();
+      expect(screen.getByText(/3\. W-9 Submitted/)).toBeTruthy();
+      expect(screen.getByText(/4\. Contract Signed/)).toBeTruthy();
+      expect(screen.getByText(/5\. Bank Account Connected/)).toBeTruthy();
+      expect(screen.getByText(/6\. Fully Onboarded/)).toBeTruthy();
+    });
+  });
+
+  it("shows action buttons for incomplete steps", async () => {
+    mockFetch(partialSteps);
+    render(<OnboardingChecklist />);
+    await waitFor(() => {
+      expect(screen.getByText("Set Password")).toBeTruthy();
+      expect(screen.getByText("Complete your W-9")).toBeTruthy();
+    });
+  });
+
+  it("renders nothing when fetch fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    const { container } = render(<OnboardingChecklist />);
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+});

--- a/src/__tests__/lib/authHelpers.test.ts
+++ b/src/__tests__/lib/authHelpers.test.ts
@@ -1,0 +1,52 @@
+import { getUserAuthMethods } from "@/lib/authHelpers";
+import type { User } from "@supabase/supabase-js";
+
+function makeUser(providers: string[]): User {
+  return {
+    app_metadata: { providers },
+  } as User;
+}
+
+describe("getUserAuthMethods", () => {
+  it("detects email (password) provider", () => {
+    const result = getUserAuthMethods(makeUser(["email"]));
+    expect(result.hasPassword).toBe(true);
+    expect(result.hasGoogle).toBe(false);
+    expect(result.isPasswordOnly).toBe(true);
+    expect(result.isGoogleOnly).toBe(false);
+  });
+
+  it("detects google provider", () => {
+    const result = getUserAuthMethods(makeUser(["google"]));
+    expect(result.hasPassword).toBe(false);
+    expect(result.hasGoogle).toBe(true);
+    expect(result.isGoogleOnly).toBe(true);
+    expect(result.isPasswordOnly).toBe(false);
+  });
+
+  it("detects both providers", () => {
+    const result = getUserAuthMethods(makeUser(["email", "google"]));
+    expect(result.hasPassword).toBe(true);
+    expect(result.hasGoogle).toBe(true);
+    expect(result.isGoogleOnly).toBe(false);
+    expect(result.isPasswordOnly).toBe(false);
+  });
+
+  it("handles null user", () => {
+    const result = getUserAuthMethods(null);
+    expect(result.hasPassword).toBe(false);
+    expect(result.hasGoogle).toBe(false);
+  });
+
+  it("handles undefined user", () => {
+    const result = getUserAuthMethods(undefined);
+    expect(result.hasPassword).toBe(false);
+    expect(result.hasGoogle).toBe(false);
+  });
+
+  it("handles empty providers array", () => {
+    const result = getUserAuthMethods(makeUser([]));
+    expect(result.hasPassword).toBe(false);
+    expect(result.hasGoogle).toBe(false);
+  });
+});

--- a/src/__tests__/lib/lessonRenderer.test.ts
+++ b/src/__tests__/lib/lessonRenderer.test.ts
@@ -1,0 +1,140 @@
+import { renderLessonBlocks, type LessonBlock } from "@/lib/lessonRenderer";
+
+function makeBlock(overrides: Partial<LessonBlock> & { block_type: string }): LessonBlock {
+  return {
+    id: "block-1",
+    lesson_id: "lesson-1",
+    content: null,
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+describe("renderLessonBlocks", () => {
+  it("returns empty string for no blocks", () => {
+    expect(renderLessonBlocks([])).toBe("");
+  });
+
+  it("renders text blocks with markdown", () => {
+    const blocks = [makeBlock({ block_type: "text", content: "**bold**" })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("lesson-block-text");
+    expect(html).toContain("<strong>bold</strong>");
+  });
+
+  it("renders text block with content.markdown object form", () => {
+    const blocks = [makeBlock({ block_type: "text", content: { markdown: "# Title" } as any })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("<h1>");
+    expect(html).toContain("Title");
+  });
+
+  it("renders image blocks", () => {
+    const blocks = [makeBlock({
+      block_type: "image",
+      content: { url: "https://example.com/img.png", alt: "A test image" } as any,
+    })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("lesson-block-image");
+    expect(html).toContain('src="https://example.com/img.png"');
+    expect(html).toContain('alt="A test image"');
+  });
+
+  it("uses signed URL for image with storage_key", () => {
+    const urlMap = new Map([["images/photo.jpg", "https://signed-url.com/photo"]]);
+    const blocks = [makeBlock({
+      block_type: "image",
+      content: { storage_key: "images/photo.jpg" } as any,
+    })];
+    const html = renderLessonBlocks(blocks, urlMap);
+    expect(html).toContain("https://signed-url.com/photo");
+  });
+
+  it("renders video blocks with captions", () => {
+    const blocks = [makeBlock({
+      block_type: "video",
+      content: { url: "https://example.com/vid.mp4", caption: "My video" } as any,
+    })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("lesson-block-video");
+    expect(html).toContain("<video");
+    expect(html).toContain("My video");
+  });
+
+  it("renders activity blocks", () => {
+    const blocks = [makeBlock({ block_type: "activity", content: "Do this activity" })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("lesson-block-activity");
+  });
+
+  it("renders quiz blocks from instructions field", () => {
+    const blocks = [makeBlock({
+      block_type: "quiz",
+      content: { instructions: "Answer these questions" } as any,
+    })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("lesson-block-quiz");
+    expect(html).toContain("Answer these questions");
+  });
+
+  it("renders presentation blocks with slide images", () => {
+    const urlMap = new Map([
+      ["slides/s1.png", "https://signed.com/s1"],
+      ["slides/s2.png", "https://signed.com/s2"],
+    ]);
+    const blocks = [makeBlock({
+      block_type: "presentation",
+      content: JSON.stringify({ slides: ["slides/s1.png", "slides/s2.png"] }),
+    })];
+    const html = renderLessonBlocks(blocks, urlMap);
+    expect(html).toContain("lesson-block-presentation");
+    expect(html).toContain("Slide 1");
+    expect(html).toContain("Slide 2");
+  });
+
+  it("shows unavailable message for presentation with no slides", () => {
+    const blocks = [makeBlock({
+      block_type: "presentation",
+      content: JSON.stringify({ slides: [] }),
+    })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain("Presentation slides unavailable");
+  });
+
+  it("sorts blocks by sort_order", () => {
+    const blocks = [
+      makeBlock({ id: "b2", block_type: "text", content: "Second", sort_order: 2 }),
+      makeBlock({ id: "b1", block_type: "text", content: "First", sort_order: 1 }),
+    ];
+    const html = renderLessonBlocks(blocks);
+    const firstIdx = html.indexOf("First");
+    const secondIdx = html.indexOf("Second");
+    expect(firstIdx).toBeLessThan(secondIdx);
+  });
+
+  it("strips script tags from text content", () => {
+    const blocks = [makeBlock({
+      block_type: "text",
+      content: 'Hello <script>alert("xss")</script> world',
+    })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).not.toContain("<script>");
+  });
+
+  it("escapes HTML attributes in image src", () => {
+    const blocks = [makeBlock({
+      block_type: "image",
+      content: { url: 'test" onload="alert(1)', alt: "safe" } as any,
+    })];
+    const html = renderLessonBlocks(blocks);
+    // The src attribute value is escaped — the raw " is turned into &quot;
+    expect(html).toContain("&quot;");
+    expect(html).not.toContain('onload="alert');
+  });
+
+  it("falls back to generic block for unknown types", () => {
+    const blocks = [makeBlock({ block_type: "custom_widget", content: "some text" })];
+    const html = renderLessonBlocks(blocks);
+    expect(html).toContain('class="lesson-block"');
+  });
+});

--- a/src/__tests__/lib/validations.test.ts
+++ b/src/__tests__/lib/validations.test.ts
@@ -1,0 +1,74 @@
+import { parseBody, logActionSchema } from "@/lib/validations";
+
+function createRequest(body: unknown): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createBadRequest(): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not json",
+  });
+}
+
+describe("parseBody", () => {
+  it("parses valid body against schema", async () => {
+    const request = createRequest({ action: "print_attempt" });
+    const result = await parseBody(request, logActionSchema);
+    expect("data" in result).toBe(true);
+    if ("data" in result) {
+      expect(result.data.action).toBe("print_attempt");
+    }
+  });
+
+  it("returns error for invalid JSON", async () => {
+    const request = createBadRequest();
+    const result = await parseBody(request, logActionSchema);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+      const body = await result.error.json();
+      expect(body.error).toBe("Invalid JSON body");
+    }
+  });
+
+  it("returns validation error for invalid data", async () => {
+    const request = createRequest({ action: "invalid_action" });
+    const result = await parseBody(request, logActionSchema);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+      const body = await result.error.json();
+      expect(body.error).toBe("Validation failed");
+      expect(body.details).toBeDefined();
+    }
+  });
+
+  it("returns validation error for missing fields", async () => {
+    const request = createRequest({});
+    const result = await parseBody(request, logActionSchema);
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("logActionSchema", () => {
+  it.each([
+    "print_attempt",
+    "copy_attempt",
+    "download_attempt",
+    "screenshot_attempt",
+  ])("accepts valid action: %s", (action) => {
+    const result = logActionSchema.safeParse({ action });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid action", () => {
+    const result = logActionSchema.safeParse({ action: "hack_attempt" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/__tests__/lib/watermark.test.ts
+++ b/src/__tests__/lib/watermark.test.ts
@@ -1,0 +1,54 @@
+import { encodeWatermark, decodeWatermark, injectWatermarkIntoHtml } from "@/lib/watermark";
+
+describe("encodeWatermark / decodeWatermark", () => {
+  it("round-trips a payload", () => {
+    const encoded = encodeWatermark(42, "2024-01-15T10:30:00.000Z");
+    const decoded = decodeWatermark(encoded);
+    expect(decoded).toBe("42:2024-01-15T10:30:00.000Z");
+  });
+
+  it("handles large employee numbers", () => {
+    const encoded = encodeWatermark(999999, "2024-06-01T00:00:00Z");
+    const decoded = decodeWatermark(encoded);
+    expect(decoded).toBe("999999:2024-06-01T00:00:00Z");
+  });
+
+  it("returns null for empty input", () => {
+    expect(decodeWatermark("")).toBeNull();
+  });
+
+  it("returns null for non-watermark text", () => {
+    expect(decodeWatermark("plain text with no zero-width chars")).toBeNull();
+  });
+});
+
+describe("injectWatermarkIntoHtml", () => {
+  it("adds print protection styles", () => {
+    const { html } = injectWatermarkIntoHtml("<p>Hello</p>", "Jane Doe", 42);
+    expect(html).toContain("@media print{body{display:none!important}}");
+  });
+
+  it("adds a visual overlay with teacher name", () => {
+    const { html } = injectWatermarkIntoHtml("<p>Hello</p>", "Jane Doe", 42);
+    expect(html).toContain("Jane Doe");
+    expect(html).toContain("#42");
+  });
+
+  it("returns a watermarkHash starting with wm_", () => {
+    const { watermarkHash } = injectWatermarkIntoHtml("<p>Hello</p>", "Jane Doe", 42);
+    expect(watermarkHash).toMatch(/^wm_42_\d+$/);
+  });
+
+  it("escapes HTML in teacher name", () => {
+    const { html } = injectWatermarkIntoHtml("<p>Hi</p>", '<script>alert("xss")</script>', 1);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("injects zero-width watermark into first paragraph", () => {
+    const input = "<p>Content here</p>";
+    const { html } = injectWatermarkIntoHtml(input, "Test", 1);
+    // The <p> tag should have zero-width chars injected after it
+    expect(html).not.toContain("<p>Content here</p>");
+  });
+});


### PR DESCRIPTION
∙	Added 9 new test files with 59 tests, bringing total from 34 to 93 tests across 15 files
	∙	Covers previously untested utilities (watermark, validations, lessonRenderer, authHelpers), API routes (lessons, users/me, onboarding-status, log-action), and the OnboardingChecklist component