### PR TITLE
Fix bank account step not showing complete after Stripe onboarding

### DIFF
--- a/src/__tests__/api/stripe/account-status.test.ts
+++ b/src/__tests__/api/stripe/account-status.test.ts
@@ -10,6 +10,14 @@ vi.mock("@/lib/supabaseAdmin", () => ({
   getSupabaseAdmin: vi.fn(),
 }));
 
+const mockAccountRetrieve = vi.fn();
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn(() => ({
+    accounts: { retrieve: mockAccountRetrieve },
+  })),
+}));
+
 import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 
@@ -28,6 +36,9 @@ function mockUserQuery(data: Record<string, unknown> | null) {
         eq: vi.fn().mockReturnValue({
           single: vi.fn().mockResolvedValue({ data, error: null }),
         }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
       }),
     }),
   };
@@ -56,19 +67,7 @@ describe("GET /api/stripe/account-status", () => {
     expect(body.status).toBe("not_started");
   });
 
-  it("returns in_progress when account exists but onboarding incomplete", async () => {
-    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
-    vi.mocked(getSupabaseAdmin).mockReturnValue(
-      mockUserQuery({ stripe_account_id: "acct_123", stripe_onboarding_complete: false }) as never
-    );
-
-    const response = await GET();
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.status).toBe("in_progress");
-  });
-
-  it("returns complete when stripe onboarding is done", async () => {
+  it("returns complete when stripe_onboarding_complete is already true", async () => {
     vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
     vi.mocked(getSupabaseAdmin).mockReturnValue(
       mockUserQuery({ stripe_account_id: "acct_123", stripe_onboarding_complete: true }) as never
@@ -78,5 +77,40 @@ describe("GET /api/stripe/account-status", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.status).toBe("complete");
+    // Should not call Stripe API when DB already says complete
+    expect(mockAccountRetrieve).not.toHaveBeenCalled();
+  });
+
+  it("checks Stripe API when DB says incomplete and returns complete if details_submitted", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      mockUserQuery({ stripe_account_id: "acct_123", stripe_onboarding_complete: false }) as never
+    );
+    mockAccountRetrieve.mockResolvedValue({
+      details_submitted: true,
+      charges_enabled: true,
+    });
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("complete");
+    expect(mockAccountRetrieve).toHaveBeenCalledWith("acct_123");
+  });
+
+  it("returns in_progress when Stripe account exists but details not submitted", async () => {
+    vi.mocked(getCurrentTeacherFromDb).mockResolvedValue(mockTeacher);
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      mockUserQuery({ stripe_account_id: "acct_123", stripe_onboarding_complete: false }) as never
+    );
+    mockAccountRetrieve.mockResolvedValue({
+      details_submitted: false,
+      charges_enabled: false,
+    });
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("in_progress");
   });
 });

--- a/src/app/api/stripe/account-status/route.ts
+++ b/src/app/api/stripe/account-status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentTeacherFromDb } from "@/lib/lessonDeliveryAuth";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import { getStripe } from "@/lib/stripe";
 import { handleApiError } from "@/lib/apiErrorHandler";
 
 export async function GET() {
@@ -22,6 +23,20 @@ export async function GET() {
     }
 
     if (user.stripe_onboarding_complete) {
+      return NextResponse.json({ status: "complete" });
+    }
+
+    // DB not yet updated — check Stripe directly (webhook may be delayed)
+    const stripe = getStripe();
+    const account = await stripe.accounts.retrieve(user.stripe_account_id);
+
+    if (account.details_submitted && account.charges_enabled) {
+      // Sync the DB so future checks are fast
+      await admin
+        .from("users")
+        .update({ stripe_onboarding_complete: true })
+        .eq("employee_number", teacher.employeeNumber);
+
       return NextResponse.json({ status: "complete" });
     }
 

--- a/src/components/OnboardingChecklist.tsx
+++ b/src/components/OnboardingChecklist.tsx
@@ -101,13 +101,43 @@ export default function OnboardingChecklist() {
   const [data, setData] = useState<OnboardingData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const fetchStatus = () =>
     fetch("/api/teacher/onboarding-status")
       .then((r) => r.json())
       .then((d: OnboardingData) => setData(d))
-      .catch(() => setData(null))
-      .finally(() => setLoading(false));
+      .catch(() => setData(null));
+
+  useEffect(() => {
+    fetchStatus().finally(() => setLoading(false));
   }, []);
+
+  // When returning from Stripe, poll account-status until it's complete
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("stripe") !== "complete" && params.get("stripe") !== "refresh") return;
+    if (data?.steps.bankConnected) return;
+
+    let attempts = 0;
+    const maxAttempts = 10;
+    const interval = setInterval(async () => {
+      attempts++;
+      try {
+        const res = await fetch("/api/stripe/account-status");
+        const { status } = await res.json();
+        if (status === "complete") {
+          clearInterval(interval);
+          fetchStatus(); // refresh all steps
+          // Clean up the URL
+          const url = new URL(window.location.href);
+          url.searchParams.delete("stripe");
+          window.history.replaceState({}, "", url.pathname);
+        }
+      } catch { /* ignore */ }
+      if (attempts >= maxAttempts) clearInterval(interval);
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [data?.steps.bankConnected]);
 
   if (loading || !data || data.steps.fullyOnboarded) return null;
 


### PR DESCRIPTION
The account-status endpoint was only checking the DB column, but the admin app's webhook may not have fired yet when Stripe redirects back. Now checks Stripe's API directly (details_submitted && charges_enabled) and syncs the DB if Stripe says it's done.

Also adds polling in the OnboardingChecklist: when the teacher returns from Stripe with ?stripe=complete, it polls /api/stripe/account-status every 2s (up to 10 times) until the status is "complete", then refreshes the checklist to show the step as done.

https://claude.ai/code/session_01BEJZGJr7BoiJHBwE16jyMi